### PR TITLE
fix: CustomAttributeTypeParameter throws ArgumentOutOfRangeException …

### DIFF
--- a/Cpp2IL.Core/Model/CustomAttributes/CustomAttributeTypeParameter.cs
+++ b/Cpp2IL.Core/Model/CustomAttributes/CustomAttributeTypeParameter.cs
@@ -54,7 +54,7 @@ public class CustomAttributeTypeParameter : BaseCustomAttributeTypeParameter
         if (TypeContext == null)
             return "(Type) null";
 
-        if (TypeContext.IsPrimitive)
+        if (TypeContext.IsPrimitive && TypeContext.Type != Il2CppTypeEnum.IL2CPP_TYPE_CLASS)
             return $"typeof({LibCpp2ILUtils.GetTypeName(TypeContext.Type)}";
 
         if (TypeContext is ReferencedTypeAnalysisContext)


### PR DESCRIPTION
…from LibCpp2ILUtils.GetTypeName if type IsPrimitive and IL2CPP_TYPE_CLASS